### PR TITLE
chore: group all renovate dependency updates into single PR

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,6 +8,8 @@
   "extends": [
     "config:recommended"
   ],
+  "groupName": "all dependencies",
+  "groupSlug": "all-deps",
   "labels": [
     "renovate"
   ],


### PR DESCRIPTION
## Summary

- Adds `groupName` and `groupSlug` to renovate config to batch all dependency updates into a single PR instead of one PR per dependency
- Reduces CI churn and Docker image builds triggered by frequent Renovate merges

__Disclosure__
This change was developed with the assistance of AI, but was reviewed and tested by a human.