### PR TITLE
Fix Renovate PR checkbox trigger

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   renovate:
+    if: startsWith(github.event.pull_request.head.ref, 'renovate/')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- Add a Renovate head-branch guard to the Renovate workflow.

## Why
- `pull_request_target.branches` filters the base branch, so `main` is the correct base target.
- The job guard keeps this workflow limited to `renovate/*` PRs instead of every PR edited on `main`.

## Change
- Keep the base-branch filter on `main`.
- Add a job-level `if` so only Renovate branches trigger the workflow.